### PR TITLE
Simplify to OpenAI with structured outputs

### DIFF
--- a/agent_graph/graph.py
+++ b/agent_graph/graph.py
@@ -4,7 +4,6 @@ from langchain_core.runnables import RunnableLambda
 from langgraph.graph import StateGraph, END
 from typing import TypedDict, Annotated
 from langchain_core.messages import HumanMessage
-from models.openai_models import get_open_ai_json
 from langgraph.checkpoint.sqlite import SqliteSaver
 from agents.agents import (
     PlannerAgent,
@@ -13,119 +12,110 @@ from agents.agents import (
     ReviewerAgent,
     RouterAgent,
     FinalReportAgent,
-    EndNodeAgent
+    EndNodeAgent,
 )
 from prompts.prompts import (
-    reviewer_prompt_template, 
-    planner_prompt_template, 
-    selector_prompt_template, 
+    reviewer_prompt_template,
+    planner_prompt_template,
+    selector_prompt_template,
     reporter_prompt_template,
     router_prompt_template,
     reviewer_guided_json,
     selector_guided_json,
     planner_guided_json,
-    router_guided_json
-
+    router_guided_json,
 )
 from tools.google_serper import get_google_serper
 from tools.basic_scraper import scrape_website
 from states.state import AgentGraphState, get_agent_graph_state, state
 
-def create_graph(server=None, model=None, stop=None, model_endpoint=None, temperature=0):
+
+def create_graph(
+    server=None, model=None, stop=None, model_endpoint=None, temperature=0
+):
     graph = StateGraph(AgentGraphState)
 
     graph.add_node(
-        "planner", 
+        "planner",
         lambda state: PlannerAgent(
-            state=state,
-            model=model,
-            server=server,
-            guided_json=planner_guided_json,
-            stop=stop,
-            model_endpoint=model_endpoint,
-            temperature=temperature
+            state=state, model=model, temperature=temperature
         ).invoke(
             research_question=state["research_question"],
-            feedback=lambda: get_agent_graph_state(state=state, state_key="reviewer_latest"),
+            feedback=lambda: get_agent_graph_state(
+                state=state, state_key="reviewer_latest"
+            ),
             # previous_plans=lambda: get_agent_graph_state(state=state, state_key="planner_all"),
-            prompt=planner_prompt_template
-        )
+            prompt=planner_prompt_template,
+        ),
     )
 
     graph.add_node(
         "selector",
         lambda state: SelectorAgent(
-            state=state,
-            model=model,
-            server=server,
-            guided_json=selector_guided_json,
-            stop=stop,
-            model_endpoint=model_endpoint,
-            temperature=temperature
+            state=state, model=model, temperature=temperature
         ).invoke(
             research_question=state["research_question"],
-            feedback=lambda: get_agent_graph_state(state=state, state_key="reviewer_latest"),
-            previous_selections=lambda: get_agent_graph_state(state=state, state_key="selector_all"),
+            feedback=lambda: get_agent_graph_state(
+                state=state, state_key="reviewer_latest"
+            ),
+            previous_selections=lambda: get_agent_graph_state(
+                state=state, state_key="selector_all"
+            ),
             serp=lambda: get_agent_graph_state(state=state, state_key="serper_latest"),
             prompt=selector_prompt_template,
-        )
+        ),
     )
 
     graph.add_node(
-        "reporter", 
+        "reporter",
         lambda state: ReporterAgent(
-            state=state,
-            model=model,
-            server=server,
-            stop=stop,
-            model_endpoint=model_endpoint,
-            temperature=temperature
+            state=state, model=model, temperature=temperature
         ).invoke(
             research_question=state["research_question"],
-            feedback=lambda: get_agent_graph_state(state=state, state_key="reviewer_latest"),
-            previous_reports=lambda: get_agent_graph_state(state=state, state_key="reporter_all"),
-            research=lambda: get_agent_graph_state(state=state, state_key="scraper_latest"),
-            prompt=reporter_prompt_template
-        )
+            feedback=lambda: get_agent_graph_state(
+                state=state, state_key="reviewer_latest"
+            ),
+            previous_reports=lambda: get_agent_graph_state(
+                state=state, state_key="reporter_all"
+            ),
+            research=lambda: get_agent_graph_state(
+                state=state, state_key="scraper_latest"
+            ),
+            prompt=reporter_prompt_template,
+        ),
     )
 
     graph.add_node(
-        "reviewer", 
+        "reviewer",
         lambda state: ReviewerAgent(
-            state=state,
-            model=model,
-            server=server,
-            guided_json=reviewer_guided_json,
-            stop=stop,
-            model_endpoint=model_endpoint,
-            temperature=temperature
+            state=state, model=model, temperature=temperature
         ).invoke(
             research_question=state["research_question"],
-            feedback=lambda: get_agent_graph_state(state=state, state_key="reviewer_all"),
+            feedback=lambda: get_agent_graph_state(
+                state=state, state_key="reviewer_all"
+            ),
             # planner=lambda: get_agent_graph_state(state=state, state_key="planner_latest"),
             # selector=lambda: get_agent_graph_state(state=state, state_key="selector_latest"),
-            reporter=lambda: get_agent_graph_state(state=state, state_key="reporter_latest"),
+            reporter=lambda: get_agent_graph_state(
+                state=state, state_key="reporter_latest"
+            ),
             # planner_agent=planner_prompt_template,
             # selector_agent=selector_prompt_template,
             # reporter_agent=reporter_prompt_template,
             # serp=lambda: get_agent_graph_state(state=state, state_key="serper_latest"),
-            prompt=reviewer_prompt_template
-        )
+            prompt=reviewer_prompt_template,
+        ),
     )
 
     graph.add_node(
-        "router", 
+        "router",
         lambda state: RouterAgent(
-            state=state,
-            model=model,
-            server=server,
-            guided_json=router_guided_json,
-            stop=stop,
-            model_endpoint=model_endpoint,
-            temperature=temperature
+            state=state, model=model, temperature=temperature
         ).invoke(
             research_question=state["research_question"],
-            feedback=lambda: get_agent_graph_state(state=state, state_key="reviewer_all"),
+            feedback=lambda: get_agent_graph_state(
+                state=state, state_key="reviewer_all"
+            ),
             # planner=lambda: get_agent_graph_state(state=state, state_key="planner_latest"),
             # selector=lambda: get_agent_graph_state(state=state, state_key="selector_latest"),
             # reporter=lambda: get_agent_graph_state(state=state, state_key="reporter_latest"),
@@ -133,34 +123,35 @@ def create_graph(server=None, model=None, stop=None, model_endpoint=None, temper
             # selector_agent=selector_prompt_template,
             # reporter_agent=reporter_prompt_template,
             # serp=lambda: get_agent_graph_state(state=state, state_key="serper_latest"),
-            prompt=router_prompt_template
-        )
+            prompt=router_prompt_template,
+        ),
     )
-
 
     graph.add_node(
         "serper_tool",
         lambda state: get_google_serper(
             state=state,
-            plan=lambda: get_agent_graph_state(state=state, state_key="planner_latest")
-        )
+            plan=lambda: get_agent_graph_state(state=state, state_key="planner_latest"),
+        ),
     )
 
     graph.add_node(
         "scraper_tool",
         lambda state: scrape_website(
             state=state,
-            research=lambda: get_agent_graph_state(state=state, state_key="selector_latest")
-        )
+            research=lambda: get_agent_graph_state(
+                state=state, state_key="selector_latest"
+            ),
+        ),
     )
 
     graph.add_node(
-        "final_report", 
-        lambda state: FinalReportAgent(
-            state=state
-        ).invoke(
-            final_response=lambda: get_agent_graph_state(state=state, state_key="reporter_latest")
-        )
+        "final_report",
+        lambda state: FinalReportAgent(state=state).invoke(
+            final_response=lambda: get_agent_graph_state(
+                state=state, state_key="reporter_latest"
+            )
+        ),
     )
 
     graph.add_node("end", lambda state: EndNodeAgent(state).invoke())
@@ -178,7 +169,7 @@ def create_graph(server=None, model=None, stop=None, model_endpoint=None, temper
                 review_content = review.content
             else:
                 review_content = review
-            
+
             review_data = json.loads(review_content)
             next_agent = review_data["next_agent"]
         else:
@@ -204,6 +195,7 @@ def create_graph(server=None, model=None, stop=None, model_endpoint=None, temper
     graph.add_edge("final_report", "end")
 
     return graph
+
 
 def compile_workflow(graph):
     workflow = graph.compile()

--- a/agents/agents.py
+++ b/agents/agents.py
@@ -2,77 +2,43 @@
 # import yaml
 # import os
 from termcolor import colored
-from models.openai_models import get_open_ai, get_open_ai_json
-from models.ollama_models import OllamaModel, OllamaJSONModel
-from models.vllm_models import VllmJSONModel, VllmModel
-from models.groq_models import GroqModel, GroqJSONModel
-from models.claude_models import ClaudModel, ClaudJSONModel
-from models.gemini_models import GeminiModel, GeminiJSONModel
+from langchain_core.messages import HumanMessage
+from models.openai_models import get_open_ai, get_open_ai_structured
+from models.agent_schemas import (
+    PlannerResponse,
+    SelectorResponse,
+    ReviewerResponse,
+    RouterResponse,
+)
 from prompts.prompts import (
     planner_prompt_template,
     selector_prompt_template,
     reporter_prompt_template,
     reviewer_prompt_template,
-    router_prompt_template
+    router_prompt_template,
 )
 from utils.helper_functions import get_current_utc_datetime, check_for_content
 from states.state import AgentGraphState
 
+
 class Agent:
-    def __init__(self, state: AgentGraphState, model=None, server=None, temperature=0, model_endpoint=None, stop=None, guided_json=None):
+    def __init__(self, state: AgentGraphState, model=None, temperature=0):
         self.state = state
         self.model = model
-        self.server = server
         self.temperature = temperature
-        self.model_endpoint = model_endpoint
-        self.stop = stop
-        self.guided_json = guided_json
 
-    def get_llm(self, json_model=True):
-        if self.server == 'openai':
-            return get_open_ai_json(model=self.model, temperature=self.temperature) if json_model else get_open_ai(model=self.model, temperature=self.temperature)
-        if self.server == 'ollama':
-            return OllamaJSONModel(model=self.model, temperature=self.temperature) if json_model else OllamaModel(model=self.model, temperature=self.temperature)
-        if self.server == 'vllm':
-            return VllmJSONModel(
-                model=self.model, 
-                guided_json=self.guided_json,
-                stop=self.stop,
-                model_endpoint=self.model_endpoint,
-                temperature=self.temperature
-            ) if json_model else VllmModel(
+    def get_llm(self, json_model=True, model_class=None):
+        if json_model and model_class is not None:
+            return get_open_ai_structured(
+                response_model=model_class,
                 model=self.model,
-                model_endpoint=self.model_endpoint,
-                stop=self.stop,
-                temperature=self.temperature
+                temperature=self.temperature,
             )
-        if self.server == 'groq':
-            return GroqJSONModel(
-                model=self.model,
-                temperature=self.temperature
-            ) if json_model else GroqModel(
-                model=self.model,
-                temperature=self.temperature
-            )
-        if self.server == 'claude':
-            return ClaudJSONModel(
-                model=self.model,
-                temperature=self.temperature
-            ) if json_model else ClaudModel(
-                model=self.model,
-                temperature=self.temperature
-            )
-        if self.server == 'gemini':
-            return GeminiJSONModel(
-                model=self.model,
-                temperature=self.temperature
-            ) if json_model else GeminiModel(
-                model=self.model,
-                temperature=self.temperature
-            )      
+        return get_open_ai(model=self.model, temperature=self.temperature)
 
     def update_state(self, key, value):
         self.state = {**self.state, key: value}
+
 
 class PlannerAgent(Agent):
     def invoke(self, research_question, prompt=planner_prompt_template, feedback=None):
@@ -80,27 +46,38 @@ class PlannerAgent(Agent):
         feedback_value = check_for_content(feedback_value)
 
         planner_prompt = prompt.format(
-            feedback=feedback_value,
-            datetime=get_current_utc_datetime()
+            feedback=feedback_value, datetime=get_current_utc_datetime()
         )
 
         messages = [
             {"role": "system", "content": planner_prompt},
-            {"role": "user", "content": f"research question: {research_question}"}
+            {"role": "user", "content": f"research question: {research_question}"},
         ]
 
-        llm = self.get_llm()
+        llm = self.get_llm(model_class=PlannerResponse)
         ai_msg = llm.invoke(messages)
-        response = ai_msg.content
+        response = ai_msg.model_dump_json()
 
-        self.update_state("planner_response", response)
-        print(colored(f"Planner 👩🏿‍💻: {response}", 'cyan'))
+        self.update_state("planner_response", HumanMessage(content=response))
+        print(colored(f"Planner 👩🏿‍💻: {response}", "cyan"))
         return self.state
 
+
 class SelectorAgent(Agent):
-    def invoke(self, research_question, prompt=selector_prompt_template, feedback=None, previous_selections=None, serp=None):
+    def invoke(
+        self,
+        research_question,
+        prompt=selector_prompt_template,
+        feedback=None,
+        previous_selections=None,
+        serp=None,
+    ):
         feedback_value = feedback() if callable(feedback) else feedback
-        previous_selections_value = previous_selections() if callable(previous_selections) else previous_selections
+        previous_selections_value = (
+            previous_selections()
+            if callable(previous_selections)
+            else previous_selections
+        )
 
         feedback_value = check_for_content(feedback_value)
         previous_selections_value = check_for_content(previous_selections_value)
@@ -109,60 +86,77 @@ class SelectorAgent(Agent):
             feedback=feedback_value,
             previous_selections=previous_selections_value,
             serp=serp().content,
-            datetime=get_current_utc_datetime()
+            datetime=get_current_utc_datetime(),
         )
 
         messages = [
             {"role": "system", "content": selector_prompt},
-            {"role": "user", "content": f"research question: {research_question}"}
+            {"role": "user", "content": f"research question: {research_question}"},
         ]
 
-        llm = self.get_llm()
+        llm = self.get_llm(model_class=SelectorResponse)
         ai_msg = llm.invoke(messages)
-        response = ai_msg.content
+        response = ai_msg.model_dump_json()
 
-        print(colored(f"selector 🧑🏼‍💻: {response}", 'green'))
-        self.update_state("selector_response", response)
+        print(colored(f"selector 🧑🏼‍💻: {response}", "green"))
+        self.update_state("selector_response", HumanMessage(content=response))
         return self.state
 
+
 class ReporterAgent(Agent):
-    def invoke(self, research_question, prompt=reporter_prompt_template, feedback=None, previous_reports=None, research=None):
+    def invoke(
+        self,
+        research_question,
+        prompt=reporter_prompt_template,
+        feedback=None,
+        previous_reports=None,
+        research=None,
+    ):
         feedback_value = feedback() if callable(feedback) else feedback
-        previous_reports_value = previous_reports() if callable(previous_reports) else previous_reports
+        previous_reports_value = (
+            previous_reports() if callable(previous_reports) else previous_reports
+        )
         research_value = research() if callable(research) else research
 
         feedback_value = check_for_content(feedback_value)
         previous_reports_value = check_for_content(previous_reports_value)
         research_value = check_for_content(research_value)
-        
+
         reporter_prompt = prompt.format(
             feedback=feedback_value,
             previous_reports=previous_reports_value,
             datetime=get_current_utc_datetime(),
-            research=research_value
+            research=research_value,
         )
 
         messages = [
             {"role": "system", "content": reporter_prompt},
-            {"role": "user", "content": f"research question: {research_question}"}
+            {"role": "user", "content": f"research question: {research_question}"},
         ]
 
         llm = self.get_llm(json_model=False)
         ai_msg = llm.invoke(messages)
         response = ai_msg.content
 
-        print(colored(f"Reporter 👨‍💻: {response}", 'yellow'))
-        self.update_state("reporter_response", response)
+        print(colored(f"Reporter 👨‍💻: {response}", "yellow"))
+        self.update_state("reporter_response", HumanMessage(content=response))
         return self.state
 
+
 class ReviewerAgent(Agent):
-    def invoke(self, research_question, prompt=reviewer_prompt_template, reporter=None, feedback=None):
+    def invoke(
+        self,
+        research_question,
+        prompt=reviewer_prompt_template,
+        reporter=None,
+        feedback=None,
+    ):
         reporter_value = reporter() if callable(reporter) else reporter
         feedback_value = feedback() if callable(feedback) else feedback
 
         reporter_value = check_for_content(reporter_value)
         feedback_value = check_for_content(feedback_value)
-        
+
         reviewer_prompt = prompt.format(
             reporter=reporter_value,
             state=self.state,
@@ -172,19 +166,22 @@ class ReviewerAgent(Agent):
 
         messages = [
             {"role": "system", "content": reviewer_prompt},
-            {"role": "user", "content": f"research question: {research_question}"}
+            {"role": "user", "content": f"research question: {research_question}"},
         ]
 
-        llm = self.get_llm()
+        llm = self.get_llm(model_class=ReviewerResponse)
         ai_msg = llm.invoke(messages)
-        response = ai_msg.content
+        response = ai_msg.model_dump_json()
 
-        print(colored(f"Reviewer 👩🏽‍⚖️: {response}", 'magenta'))
-        self.update_state("reviewer_response", response)
+        print(colored(f"Reviewer 👩🏽‍⚖️: {response}", "magenta"))
+        self.update_state("reviewer_response", HumanMessage(content=response))
         return self.state
-    
+
+
 class RouterAgent(Agent):
-    def invoke(self, feedback=None, research_question=None, prompt=router_prompt_template):
+    def invoke(
+        self, feedback=None, research_question=None, prompt=router_prompt_template
+    ):
         feedback_value = feedback() if callable(feedback) else feedback
         feedback_value = check_for_content(feedback_value)
 
@@ -192,25 +189,29 @@ class RouterAgent(Agent):
 
         messages = [
             {"role": "system", "content": router_prompt},
-            {"role": "user", "content": f"research question: {research_question}"}
+            {"role": "user", "content": f"research question: {research_question}"},
         ]
 
-        llm = self.get_llm()
+        llm = self.get_llm(model_class=RouterResponse)
         ai_msg = llm.invoke(messages)
-        response = ai_msg.content
+        response = ai_msg.model_dump_json()
 
-        print(colored(f"Router 🧭: {response}", 'blue'))
-        self.update_state("router_response", response)
+        print(colored(f"Router 🧭: {response}", "blue"))
+        self.update_state("router_response", HumanMessage(content=response))
         return self.state
+
 
 class FinalReportAgent(Agent):
     def invoke(self, final_response=None):
-        final_response_value = final_response() if callable(final_response) else final_response
+        final_response_value = (
+            final_response() if callable(final_response) else final_response
+        )
         response = final_response_value.content
 
-        print(colored(f"Final Report 📝: {response}", 'blue'))
+        print(colored(f"Final Report 📝: {response}", "blue"))
         self.update_state("final_reports", response)
         return self.state
+
 
 class EndNodeAgent(Agent):
     def invoke(self):

--- a/models/agent_schemas.py
+++ b/models/agent_schemas.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+
+
+class PlannerResponse(BaseModel):
+    search_term: str
+    overall_strategy: str
+    additional_information: str
+
+
+class SelectorResponse(BaseModel):
+    selected_page_url: str
+    description: str
+    reason_for_selection: str
+
+
+class ReviewerResponse(BaseModel):
+    feedback: str
+    pass_review: bool
+    comprehensive: bool
+    citations_provided: bool
+    relevant_to_research_question: bool
+
+
+class RouterResponse(BaseModel):
+    next_agent: str

--- a/models/openai_models.py
+++ b/models/openai_models.py
@@ -2,22 +2,28 @@ from langchain_openai import ChatOpenAI
 from utils.helper_functions import load_config
 import os
 
-config_path = os.path.join(os.path.dirname(__file__), '..', 'config', 'config.yaml')
+config_path = os.path.join(os.path.dirname(__file__), "..", "config", "config.yaml")
 load_config(config_path)
 
 
-def get_open_ai(temperature=0, model='gpt-3.5-turbo'):
+BASE_URL = os.environ.get("OPENAI_BASE_URL", "http://localhost:11434/v1")
 
+
+def get_open_ai(temperature: float = 0, model: str = "gpt-3.5-turbo"):
     llm = ChatOpenAI(
-    model=model,
-    temperature = temperature,
-)
+        model=model,
+        temperature=temperature,
+        base_url=BASE_URL,
+    )
     return llm
 
-def get_open_ai_json(temperature=0, model='gpt-3.5-turbo'):
+
+def get_open_ai_structured(
+    response_model, temperature: float = 0, model: str = "gpt-3.5-turbo"
+):
     llm = ChatOpenAI(
-    model=model,
-    temperature = temperature,
-    model_kwargs={"response_format": {"type": "json_object"}},
-)
+        model=model,
+        temperature=temperature,
+        base_url=BASE_URL,
+    ).with_structured_output(response_model)
     return llm


### PR DESCRIPTION
## Summary
- add output schemas for planner, selector, reviewer and router
- simplify models to use `langchain_openai` with ollama base URL
- rely exclusively on OpenAI and remove other model code paths
- use structured output via Pydantic models in agents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1232d904832f8763cc403f418236